### PR TITLE
Greater support for custom console logs (tag, colorization)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "drpg-logger",
-	"version": "1.3.1",
+	"version": "1.4.0",
 	"author": "Bejasc",
 	"repository": {
 		"type": "git",

--- a/src/config/DefaultLogTypes.ts
+++ b/src/config/DefaultLogTypes.ts
@@ -1,51 +1,63 @@
-import { bgRed, cyan, gray, magenta, red, yellow } from "colorette";
 import { DrpgColors } from "drpg-utils";
 import { ILogType } from "../types/ILogType";
+import { ConsoleColor, ConsoleColorMode } from "../functions/coloretteResolver";
 
 export const LogLevel = {
 	Trace: {
 		priority: 10,
 		title: "Trace",
 		embedColor: DrpgColors.white,
-		logTag: `${gray("%T")} - ${gray("TRACE")}`,
+		consoleColorMode: ConsoleColorMode.TagOnly,
+		consoleColor: ConsoleColor.gray,
+		logTag: "TRACE",
 	} as ILogType,
 
 	Debug: {
 		priority: 20,
 		title: "Debug",
 		embedColor: DrpgColors.yellow,
-		logTag: `${magenta("%T")} - ${magenta("DEBUG")}`,
+		consoleColorMode: ConsoleColorMode.TagOnly,
+		consoleColor: ConsoleColor.magenta,
+		logTag: "DEBUG",
 	} as ILogType,
 
 	Info: {
 		priority: 30,
 		title: "Info",
 		embedColor: DrpgColors.blue,
-		logTag: `${cyan("%T")} - ${cyan("INFO")}`,
 		emoji: "ℹ",
+		consoleColorMode: ConsoleColorMode.TagOnly,
+		consoleColor: ConsoleColor.cyan,
+		logTag: "INFO",
 	} as ILogType,
 
 	Warn: {
 		priority: 40,
 		title: "Warning",
 		embedColor: DrpgColors.orange,
-		logTag: `${yellow("%T")} - ${yellow("WARNING")}`,
 		emoji: "⚠",
+		consoleColorMode: ConsoleColorMode.TagOnly,
+		consoleColor: ConsoleColor.yellow,
+		logTag: "WARNING",
 	} as ILogType,
 
 	Error: {
 		priority: 50,
 		title: "Error",
 		embedColor: DrpgColors.red,
-		logTag: `${red("%T")} - ${red("ERROR")}`,
 		emoji: "‼",
+		consoleColorMode: ConsoleColorMode.TagOnly,
+		consoleColor: ConsoleColor.red,
+		logTag: "ERROR",
 	} as ILogType,
 
 	Fatal: {
 		priority: 60,
 		title: "Fatal",
 		embedColor: DrpgColors.black,
-		logTag: `${bgRed("%T")} - ${bgRed("FATAL")}`,
 		emoji: "☠",
+		consoleColorMode: ConsoleColorMode.Full,
+		consoleColor: ConsoleColor.bgRed,
+		logTag: "FATAL",
 	} as ILogType,
 };

--- a/src/functions/coloretteResolver.ts
+++ b/src/functions/coloretteResolver.ts
@@ -1,0 +1,58 @@
+import { bgRed, red, green, yellow, blue, magenta, cyan, white, redBright, greenBright, yellowBright, blueBright, magentaBright, cyanBright, whiteBright, gray } from "colorette";
+
+export enum ConsoleColor {
+	red,
+	green,
+	yellow,
+	blue,
+	magenta,
+	cyan,
+	redBright,
+	greenBright,
+	yellowBright,
+	blueBright,
+	magentaBright,
+	cyanBright,
+	gray,
+	bgRed,
+}
+
+export enum ConsoleColorMode {
+	TagOnly,
+	Full,
+}
+
+export function colorizeText(content: string, color: ConsoleColor) {
+	switch (color) {
+		case ConsoleColor.blue:
+			return blue(content);
+		case ConsoleColor.blueBright:
+			return blueBright(content);
+		case ConsoleColor.cyan:
+			return cyan(content);
+		case ConsoleColor.cyanBright:
+			return cyanBright(content);
+		case ConsoleColor.green:
+			return green(content);
+		case ConsoleColor.greenBright:
+			return greenBright(content);
+		case ConsoleColor.magenta:
+			return magenta(content);
+		case ConsoleColor.magentaBright:
+			return magentaBright(content);
+		case ConsoleColor.red:
+			return red(content);
+		case ConsoleColor.redBright:
+			return redBright(content);
+		case ConsoleColor.yellow:
+			return yellow(content);
+		case ConsoleColor.yellowBright:
+			return yellowBright(content);
+		case ConsoleColor.gray:
+			return gray(content);
+		case ConsoleColor.bgRed:
+			return bgRed(content);
+		default:
+			return whiteBright(content);
+	}
+}

--- a/src/functions/logToConsole.ts
+++ b/src/functions/logToConsole.ts
@@ -16,9 +16,9 @@ export default function ({ type, content, title, options }: { type: ILogType; co
 
 	if (title) content = bold(title + ": ") + content;
 
-	content = (type.logTag ?? `${greenBright("%T")} - ${greenBright("CUSTOM")}`) + " - " + content;
-
-	content = content.replace("%T", getTimestamp(options));
+	//content = (type.logTag ?? `${greenBright("%T")} - ${greenBright("CUSTOM")}`) + " - " + content;
+	content = `%T - ${colorizeText(type.logTag, type.consoleColor)} - ${content}`;
+	content = content.replace("%T", colorizeText(getTimestamp(options), type.consoleColor));
 
 	const method = type.method ?? "log";
 	console[method](content);

--- a/src/functions/logToConsole.ts
+++ b/src/functions/logToConsole.ts
@@ -1,11 +1,14 @@
-import { bold, greenBright, cyan, yellow } from "colorette";
+import { bold, cyan, yellow } from "colorette";
 import { Client, TextChannel } from "discord.js";
 import moment from "moment";
 import { ILoggerOptions } from "../types";
 import { ILogType } from "../types/ILogType";
+import { colorizeText, ConsoleColorMode } from "./coloretteResolver";
 /**@internal */
 
 export default function ({ type, content, title, options }: { type: ILogType; content: string; title?: string; options: ILoggerOptions }): void {
+	if (type.consoleColorMode == ConsoleColorMode.Full) content = colorizeText(content, type.consoleColor);
+
 	if (options.client) {
 		content = parseMentions(content, options.client);
 		content = parseChannels(content, options.client);

--- a/src/types/ILogType.ts
+++ b/src/types/ILogType.ts
@@ -1,10 +1,15 @@
+import { Color } from "colorette";
+import { ConsoleColor, ConsoleColorMode } from "../functions/coloretteResolver";
+
 export interface ILogType {
-	priority: number;
+	priority?: number;
 	title?: string;
 	embedColor?: string;
+	consoleColor?: ConsoleColor;
+	consoleColorMode?: ConsoleColorMode;
 	logChannel?: string;
 	logTag?: string;
 	method?: "trace" | "debug" | "info" | "warn" | "error" | "log";
 	emoji?: string;
-	thumbnail?:string
+	thumbnail?: string;
 }


### PR DESCRIPTION
- Log Tags are now applied independently of timestamp. This means you can now provide _just_ the tag, and the console log will keep the timestamp format
- Colorization for console logs is no-longer hard coded, and can be configured on a per LogType basis
- Full lines can be in color, rather than tag only. Configurable in the LogType.
- Priority made optional on the LogType, which means custom log types can now correctly spread an existing log type for absolutely minimal config. 

Also as part of this change, the default LogType definitions had their configs adjusted so that they no-longer provide the timestamp themselves, and the colorization happens outside of the logType itself.